### PR TITLE
Updating lith_name_map dictionary

### DIFF
--- a/clnutils/attr.py
+++ b/clnutils/attr.py
@@ -51,6 +51,7 @@ lith_name_map = {
     "CVN": "FLTZ",
     "QSBX": "QABX",
     "P4": "P2",
+    "P6": "P2",    # JVG Based on Ross Hammett's 9/7/2023 email
     "QVN": "FLTH",
     "SVN": "MYLO",
     "DDRT": "K4",


### PR DESCRIPTION
Per Ross's email "...Use P2 for P4 and P6. Please let me know if there are any other codes in New_Lith_Code_D  that is not listed in the KSM 2021 codes and I will sort out what to use. " Added P6 to dictionary and mapping to P2